### PR TITLE
Bump to latest stable version of ST3.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,7 +3,7 @@
 # Usage:
 #
 #     include sublime_text
-class sublime_text($build = '3059') {
+class sublime_text($build = '3065') {
   package { 'Sublime Text':
     provider => 'appdmg',
     source   => "http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%20Build%20${build}.dmg";

--- a/spec/classes/sublime_text_spec.rb
+++ b/spec/classes/sublime_text_spec.rb
@@ -1,10 +1,12 @@
 require 'spec_helper'
 
 describe 'sublime_text' do
+  let(:build_version) { '3065' }
   it do
     should contain_package('Sublime Text').with({
       :provider => 'appdmg',
-      :source   => 'http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%20Build%203059.dmg'
+      :source   => 'http://c758482.r82.cf2.rackcdn.com/' +
+                   "Sublime%20Text%20Build%20#{build_version}.dmg"
     })
   end
 end


### PR DESCRIPTION
Installs the latest stable version of ST3.

As an aside: I get `Invalid resource type repository` when I run the full test suite—is there some trick to making that available? It's listed in `spec/fixtures/Puppetfile`.
