### PR TITLE
Install stable Package Control by default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,8 @@
 #
 #     include sublime_text
 class sublime_text($build = '3065') {
+  require sublime_text::config
+
   package { 'Sublime Text':
     provider => 'appdmg',
     source   => "http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%20Build%20${build}.dmg";
@@ -14,6 +16,12 @@ class sublime_text($build = '3065') {
     target  => '/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl',
     mode    => '0755',
     require => Package['Sublime Text'],
+  }
+
+  repository { "${sublime_text::config::packagedir}/Package Control":
+    ensure  => '6a8b91ca58d66cb495b383d9572bb801316bcec5',
+    source  => 'wbond/sublime_package_control',
+    require => Package['Sublime Text']
   }
 }
 


### PR DESCRIPTION
This is to help ensure Boxen users use a stable Package Control version if automating the install with Boxen. It's important to explicitly to download and install the 2.0.0 version, which will be auto-updated to 3.0 when it is released. 
